### PR TITLE
对Python版本的健康打卡进行一下例行维护

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.7-buster
+LABEL maintainer="CharlieJ107<charlie_j107@outlook.com>"
+LABEL version="2021-10-20"
+ENV XMU_USERNAME=""
+ENV XMU_PASSWORD=""
+
+ADD ./* /daily-report
+WORKDIR /daily-report
+
+RUN pip install -r ./requirements.txt ;
+
+CMD while : ; do /usr/bin/python /daily-report/app.py $XMU_USERNAME $XMU_PASSWORD check; sleep 24h; done

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV XMU_PASSWORD=""
 ADD ./* /daily-report/
 WORKDIR /daily-report
 
-RUN pip install -r ./requirements.txt ;
+RUN pip config set global.index-url https://mirrors.cloud.tencent.com/pypi/simple; \
+    pip install --no-cache-dir -r ./requirements.txt ;
 
-CMD while : ; do /usr/bin/python /daily-report/app.py $XMU_USERNAME $XMU_PASSWORD check; sleep 24h; done
+CMD bash -c "while : ; do /usr/local/bin/python /daily-report/app.py $XMU_USERNAME $XMU_PASSWORD check; sleep 24h; done"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /daily-report
 RUN pip config set global.index-url https://mirrors.cloud.tencent.com/pypi/simple; \
     pip install --no-cache-dir -r ./requirements.txt ;
 
-CMD bash -c "while : ; do /usr/local/bin/python /daily-report/app.py $XMU_USERNAME $XMU_PASSWORD check; sleep 24h; done"
+CMD bash -c "while : ; do /usr/local/bin/python /daily-report/app.py $XMU_USERNAME $XMU_PASSWORD check; TZ='Asia/Shanghai' date; sleep 24h; done"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL version="2021-10-20"
 ENV XMU_USERNAME=""
 ENV XMU_PASSWORD=""
 
-ADD ./* /daily-report
+ADD ./* /daily-report/
 WORKDIR /daily-report
 
 RUN pip install -r ./requirements.txt ;

--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@
 
 ## 更新日志
 
+> 2021/10/19 使用`pycryptodomex`替换了使用ExecJS调用CryptoJS进行ASE加密的逻辑, 并增加了Docker支持
+> 
 > <s>2021/6/25: 更新了反代验证，现在必须要设置 --vpn-username 和 --vpn-password 才可以使用本程序。  </s>
-2021/3/30: 更新了通过 WebVPN 访问学工系统的支持，请查看文档以了解使用方法；但未对 GitHub Workflow 进行修改。  
-2021/12/27: 更新了对统一身份认证系统登录提交信息时 AES 加密的支持
+> 
+> 2021/3/30: 更新了通过 WebVPN 访问学工系统的支持，请查看文档以了解使用方法；但未对 GitHub Workflow 进行修改。
+> 
+> 2020/12/27: 更新了对统一身份认证系统登录提交信息时 AES 加密的支持
+
 
 ## 免责声明
 
@@ -45,6 +50,14 @@
 
 - 对于拥有独立服务器 (VPS) 的用户，可以选择使用 Linux 计划任务完成打卡，具体设置方法详见 [在本地 / 服务器使用](#在本地--服务器使用) 和 [使用 Linux 计划任务 (Crontab) 自动打卡](#使用-linux-计划任务-crontab-自动打卡)。
 
+- 如果你比较喜欢用Docker, 也可以使用Docker容器自动打卡, 使用方法: 
+  ```shell
+  docker run -d --name daily-report \
+  -e XMU_USERNAME="你的学工号" \
+  -e XMU_PASSWORD="你的密码" \
+  eric107/xmu-daily-report:latest
+  ```
+  你也可以自己构建属于你自己的Docker镜像
 ## 在本地 / 服务器使用
 
 此程序基于 Python 3 **和 Node.js 环境**，需要 `requests` 和 `BeautiuflSoup, lxml` 库支持以发送网络请求、解析网页。
@@ -57,7 +70,7 @@
 
 如果你的电脑已经安装了 Git，可以使用下面的命令拉取源代码：
 ```bash
-git clone https://github.com/kirainmoe/auto-daily-health-report
+git clone https://github.com/charlieJ107/auto-daily-health-report
 ```
 
 ### 安装依赖

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import argparse
 import json
 

--- a/auto-report.cron
+++ b/auto-report.cron
@@ -1,1 +1,1 @@
-30 7/24 * * * /usr/bin/python /path/to/checkin.py [username] [password]
+30 7/24 * * * /usr/bin/python /daily-report/app.py $XMU_USERNAME $XMU_PASSWORD check

--- a/captcha.py
+++ b/captcha.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import base64
 import json
 import numpy

--- a/checkin.py
+++ b/checkin.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import requests
 import json
 import sys

--- a/login.py
+++ b/login.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import sys
 

--- a/login.py
+++ b/login.py
@@ -1,10 +1,9 @@
-import requests
 import json
 import sys
-import os
-import execjs
 
 from bs4 import BeautifulSoup
+
+from utils import encryptAES
 from utils import get_wrapped_url
 
 
@@ -19,12 +18,13 @@ def login(session, username, password, http_header, use_webvpn=False):
     """
 
     # workaround for the AES encryption added in 2020/12/27
-    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "encrypt.js"), "r") as file:
-        cryptjs = file.read()
-    ctx = execjs.compile(cryptjs)
+    # with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "encrypt.js"), "r") as file:
+    #     cryptjs = file.read()
+    # ctx = execjs.compile(cryptjs)
 
     try:
-        oauth_login_url = get_wrapped_url("https://ids.xmu.edu.cn/authserver/login?service=https://xmuxg.xmu.edu.cn/login/cas/xmu", use_webvpn)
+        oauth_login_url = get_wrapped_url(
+            "https://ids.xmu.edu.cn/authserver/login?service=https://xmuxg.xmu.edu.cn/login/cas/xmu", use_webvpn)
         resp = session.get(oauth_login_url, headers=http_header)
 
         soup = BeautifulSoup(resp.text, 'html.parser')
@@ -35,7 +35,7 @@ def login(session, username, password, http_header, use_webvpn=False):
 
         login_data = {
             "username": username,
-            "password": ctx.call("encryptAES", password, salt),
+            "password": encryptAES(password, salt),
             "lt": lt,
             "dllt": dllt,
             "execution": execution,

--- a/recent.py
+++ b/recent.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import requests
 import json
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.23.0
 beautifulsoup4==4.9.0
-PyExecJS==1.5.1
+pycryptodomex==3.11.0
 numpy==1.21.0
 Pillow==8.2.0

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import base64
 import random
 

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,40 @@
+import base64
+import random
+
+from Cryptodome.Cipher import AES
+from Cryptodome.Util.Padding import pad
+
+
 def get_wrapped_url(url, webvpn=False):
     if not webvpn:
         return url
 
     if "ids.xmu.edu.cn" in url:
-        return url.replace("ids.xmu.edu.cn", "webvpn.xmu.edu.cn/https/77726476706e69737468656265737421f9f352d23f3d7d1e7b0c9ce29b5b")
-    
+        return url.replace("ids.xmu.edu.cn",
+                           "webvpn.xmu.edu.cn/https/77726476706e69737468656265737421f9f352d23f3d7d1e7b0c9ce29b5b")
+
     if "xmuxg.xmu.edu.cn" in url:
-        return url.replace("xmuxg.xmu.edu.cn", "webvpn.xmu.edu.cn/https/77726476706e69737468656265737421e8fa5484207e705d6b468ca88d1b203b")
+        return url.replace("xmuxg.xmu.edu.cn",
+                           "webvpn.xmu.edu.cn/https/77726476706e69737468656265737421e8fa5484207e705d6b468ca88d1b203b")
+
+
+def encryptAES(data: str, salt: str):
+    salt = salt.encode('utf-8')
+    iv = randstr(16).encode('utf-8')
+    cipher = AES.new(salt, AES.MODE_CBC, iv)
+    data = randstr(64) + data
+    data = data.encode('utf-8')
+    data = pad(data, 16, 'pkcs7')
+    cipher_text = cipher.encrypt(data)
+    encoded64 = str(base64.encodebytes(cipher_text), encoding='utf-8').replace("\n", "")
+    return encoded64
+
+
+def randstr(num):
+    H = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+
+    salt = ''
+    for i in range(num):
+        salt += random.choice(H)
+
+    return salt

--- a/webvpn.py
+++ b/webvpn.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import requests
 import json
 import sys

--- a/workflow.py
+++ b/workflow.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import requests
 import sys
 import os


### PR DESCRIPTION
考虑到Python版本的健康打卡用户群体依然存在, 且原作者kirainmoe已经停止对旧版Python健康打卡的维护, 借这个PR, 进行一些例行维护.

十分感谢kirainmoe对坚持维护这个项目, 强烈支持并期待接下来的Rust版本的CLI程序和SDK. 致敬!

本次例行维护包含如下内容:

* 使用pycryptodomex对AES加密逻辑进行了替换, 以取代之前使用ExecJS调用CryptoJS的方式进行的加密.
* 增加了一个Dockerfile, 并提供了根据这个Dockerfile构建的Docker镜像eric107/xmu-daily-report. 用户可以通过运行这个镜像来实现自动健康打卡.
* 其他的一些小修改， 比如给每个文件添加了字符编码注释避免在类Unix系统上出现Python由于默认使用ASCII编码读取代码文件导致格式错误的问题

如果发现有什么地方存在Bug，请提交Issue。

再次感谢原作者的辛勤付出和所有人的支持。